### PR TITLE
Only allow vr controls if actually in vr

### DIFF
--- a/VRChatVibratorController/Toy.cs
+++ b/VRChatVibratorController/Toy.cs
@@ -3,10 +3,11 @@ using Buttplug;
 using System.Collections.Generic;
 using System;
 using System.Linq;
+using UnityEngine.XR;
 
 namespace Vibrator_Controller {
     public enum Hand {
-        none, shared, left, right, both, either
+        none, shared, left, right, both, either, actionmenu
     }
     public class Toy {
         internal static Dictionary<ulong, Toy> remoteToys { get; set; } = new Dictionary<ulong, Toy>();
@@ -233,6 +234,9 @@ namespace Vibrator_Controller {
                 hand++;
             if (hand == Hand.both && !supportsTwoVibrators)
                 hand++;
+
+            if (!XRDevice.isPresent && (hand == Hand.both || hand == Hand.either || hand == Hand.left || hand == Hand.right))
+                hand = Hand.actionmenu;
 
             if (isLocal()) {
                 if (hand == Hand.shared) {

--- a/VRChatVibratorController/VibratorController.cs
+++ b/VRChatVibratorController/VibratorController.cs
@@ -222,7 +222,7 @@ namespace Vibrator_Controller {
             }
 
             foreach (Toy toy in Toy.allToys) {
-                if (toy.hand == Hand.shared) return;
+                if (toy.hand == Hand.shared || toy.hand == Hand.none || toy.hand == Hand.actionmenu) return;
                 if (lockSpeed) return;
                 if (menuOpen()) return;
 


### PR DESCRIPTION
Currently if not in vr using the actionmenu is mostly impossible since vr controls are also active

Needs UnityEngine.VRModule.dll